### PR TITLE
Remove @JsonIgnore so the participants list is included in responses

### DIFF
--- a/src/main/java/com/company/enroller/model/Meeting.java
+++ b/src/main/java/com/company/enroller/model/Meeting.java
@@ -34,7 +34,6 @@ public class Meeting {
 	@Column
 	private String date;
 
-	@JsonIgnore
 	@ManyToMany(mappedBy = "meetings", cascade = { CascadeType.PERSIST, CascadeType.MERGE })
 	@JoinTable(name = "meeting_participant", joinColumns = { @JoinColumn(name = "meeting_id") }, inverseJoinColumns = {
 			@JoinColumn(name = "participant_login") })


### PR DESCRIPTION
Pani Oliwio,
Gdy na aktualnym kodzie mastera otworzy Pani aplikację, po dodaniu spotkania i odświeżeniu strony rzeczywiście lista spotkań nie pokazuje się. Zaglądnięcie jednak do konsoli JS (F12 -> Console) pokaże Pani błąd wykonania JS:

```
[Vue warn]: Error in render: "TypeError: Cannot read property 'indexOf' of undefined"

found in

---> <MeetingsList> at src\meetings\MeetingsList.vue
       <MeetingsPage> at src\meetings\MeetingsPage.vue
         <App> at src\App.vue
           <Root>
```

Okazuje się, że wyrażenie warunkowe [`v-if="meeting.participants.indexOf(username) < 0"`](https://github.com/OliwiaLakatosz/enroller-fullstack/blob/65f2f3d142e07b7abf41a3235085c9bc6b748c39/src/main/frontend/src/meetings/MeetingsList.vue#L23) powoduje odwołanie się do tablicy `participants` w obiekcie `meeting`, która nie istnieje.

Można by próbować to tu naprawiać w stylu "sprawdź najpierw czy jest tablica a potem dopiero szukaj elementu": `v-if="meeting.participants && meeting.participants.indexOf(username) < 0"`, ale lepiej skupić się na tym dlaczego tej tablicy tam nie ma gdy obiekt wraca z backendu? Rzut oka na encję - wyignorowaliśmy to pole przy serializacji. Usunięcie adnotacji naprawia problem.

Od razu zwrócę uwagę, że spotkanie do listy powinno się dodać dopiero gdy serwer odpowie że się udało. [Ta linia](https://github.com/OliwiaLakatosz/enroller-fullstack/blob/65f2f3d142e07b7abf41a3235085c9bc6b748c39/src/main/frontend/src/meetings/MeetingsPage.vue#L34) powoduej dodanie spotkanie przed requestem, a potem dodaje się drugi raz - po jego zakończeniu.